### PR TITLE
more reliable globbing

### DIFF
--- a/etc_ssl.run
+++ b/etc_ssl.run
@@ -25,6 +25,7 @@
 use strict;
 
 use File::Basename;
+use File::Glob ':glob';
 use Getopt::Long;
 
 my $etccertsdir = "/etc/ssl/certs";
@@ -86,12 +87,12 @@ GetOptions(
 
 system("trust", "extract", "--purpose=server-auth", "--filter=ca-anchors", "--format=pem-directory", "-f", $pemdir) == 0 or die;
 
-for my $f (<"$pemdir/*.pem">) {
+for my $f (glob("$pemdir/*.pem")) {
 	addcert($f);
 }
 
 # clean dangling symlinks
-for my $f (<"$etccertsdir/*.pem">) {
+for my $f (glob("$etccertsdir/*.pem")) {
 	unless (-l $f) {
 		print STDERR "$f is in the wrong location *)\n";
 		$foundignored = 1;

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -26,6 +26,7 @@
 use strict;
 
 use File::Basename;
+use File::Glob ':glob';
 use Getopt::Long;
 
 my $hooksdir1 = '/etc/ca-certificates/update.d';


### PR DESCRIPTION
Looks like perl's default globbing behavior has changed last versions. It's
more safe to use File::Glob ':glob' and glob() instead of <>.
Now we are portable again for old suse versions (e.g. 11.4).
