### PR TITLE
Make certbundle.run container friendly

### DIFF
--- a/certbundle.run
+++ b/certbundle.run
@@ -18,7 +18,8 @@ if [ -z "$fresh" -a "$cafile" -nt "$cadir" ]; then
 	exit 0
 fi
 [ -z "$verbose" ] || echo "creating $cafile ..."
-cat > "$cafile.new" <<EOF
+trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors $cafile.tmp
+cat - $cafile.tmp > "$cafile.new" <<EOF
 #
 # automatically created by $0. Do not edit!
 #
@@ -31,7 +32,5 @@ cat > "$cafile.new" <<EOF
 # - gnutls: gnutls_certificate_set_x509_system_trust(cred)
 #
 EOF
-trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors $cafile.tmp
-cat $cafile.tmp >> $cafile.new
 rm -f $cafile.tmp
-mv "$cafile.new" "$cafile"
+mv -f "$cafile.new" "$cafile"


### PR DESCRIPTION
Running containerized services and applications in the context of
privileged users is a practice highly discouraged. This creates a
problem, given that said services and applications also require
a runtime container initialization stage during which container-wide
configuration changes are made, some of which include installing custom
certificates.

To solve this problem, some prefer using non-privileged user to install
custom certificates, which in the context of `ca-certificates` requires
changing the ownership of the `/var/lib/ca-certificates` folder and
running `update-ca-certificates` as a regular user. However, not all
of the `ca-certificates` scripts are designed to be executed by a
regular user.

This commit makes changes to the `certbundle.run` script to allow it
to be executed as a regular user (i.e. its previous form runs into
errors because newly created files have 444 permissions and a regular
user isn't allowed to modify them without explicitly setting the
owner write permission bit.