### PR TITLE
Make sure to trigger in transactional mode (boo#1179884)

### DIFF
--- a/ca-certificates.path
+++ b/ca-certificates.path
@@ -4,6 +4,7 @@ After=local-fs.target
 
 [Path]
 Unit=ca-certificates.service
+PathExists=/etc/pki/trust/.updated
 PathChanged=/usr/share/pki/trust
 PathChanged=/usr/share/pki/trust/anchors
 PathChanged=/usr/share/pki/trust/blacklist

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -53,10 +53,12 @@ umask 0222;
 
 case "${TRANSACTIONAL_UPDATE,,*}" in
     true|yes|1)
-        [ -z "$verbose" ] || echo "transactional update in progress, not running any scripts" >&2
-        exit 0
-        ;;
+	[ -z "$verbose" ] || echo "transactional update in progress, not running any scripts" >&2
+	> /etc/pki/trust/.updated
+	exit 0
+	;;
 esac
+rm -f /etc/pki/trust/.updated
 
 while read s f; do
     if [ -L "$f" -a "`readlink "$f"`" = "/dev/null" ]; then


### PR DESCRIPTION
Touching /etc/pki/trust/.updated in transactional mode is a bit dirty
but the only way atm to trigger the path unit on next boot.