### PR TITLE
Add --root <directory> option

### DIFF
--- a/certbundle.run
+++ b/certbundle.run
@@ -4,8 +4,8 @@
 set -e
 
 [ -d "$statedir" ]
-cafile="$statedir/ca-bundle.pem"
-cadir="$statedir/pem"
+cafile="$destdir/$statedir/ca-bundle.pem"
+cadir="$destdir/$statedir/pem"
 
 for i in "$@"; do
     if [ "$i" = "-f" ]; then
@@ -35,7 +35,7 @@ cat - $cafile.tmp > "$cafile.new" <<EOF
 EOF
 rm -f $cafile.tmp
 mv -f "$cafile.new" "$cafile"
-if ! test -e /etc/ssl/ca-bundle.pem && ! test -L /etc/ssl/ca-bundle.pem; then
-    [ -z "$verbose" ] || echo "restoring /etc/ssl/ca-bundle.pem ..."
-    ln -s ../../var/lib/ca-certificates/ca-bundle.pem /etc/ssl/ca-bundle.pem
+if ! test -e $destdir/etc/ssl/ca-bundle.pem && ! test -L $destdir/etc/ssl/ca-bundle.pem; then
+    [ -z "$verbose" ] || echo "restoring $destdir/etc/ssl/ca-bundle.pem ..."
+    ln -s ../../var/lib/ca-certificates/ca-bundle.pem $destdir/etc/ssl/ca-bundle.pem
 fi

--- a/etc_ssl.run
+++ b/etc_ssl.run
@@ -6,7 +6,7 @@
 # Author: Ludwig Nussel
 #
 # update /etc/ssl/certs for compatibility with legacy applications
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -24,7 +24,7 @@
 #
 
 [ -d "$statedir" ]
-etccertsdir="/etc/ssl/certs"
+etccertsdir="${destdir}/etc/ssl/certs"
 pemdir="$statedir/pem"
 
 help_and_exit()
@@ -46,8 +46,8 @@ case "$1" in
     -*) echo "invalid option: $1" >&2; exit 1 ;;
 esac
 
-mkdir -p "$pemdir"
-trust extract --purpose=server-auth --filter=ca-anchors --format=pem-directory-hash -f "$pemdir"
+mkdir -p "${destdir}$pemdir"
+trust extract --purpose=server-auth --filter=ca-anchors --format=pem-directory-hash -f "${destdir}$pemdir"
 
 # fix up /etc/ssl/certs if it's not a link pointing to /var/lib/ca-certificates/pem
 if ! [ -L "$etccertsdir" -a "`readlink $etccertsdir`" = "../..$pemdir" ]; then

--- a/java.run
+++ b/java.run
@@ -3,8 +3,8 @@
 set -e
 
 [ -d "$statedir" ]
-cafile="$statedir/java-cacerts"
-cafile_gcj="$statedir/gcj-cacerts"
+cafile="$destdir/$statedir/java-cacerts"
+cafile_gcj="$destdir/$statedir/gcj-cacerts"
 
 
 for i in "$@"; do

--- a/openssl.run
+++ b/openssl.run
@@ -3,7 +3,7 @@
 set -e
 
 [ -d "$statedir" ]
-cadir="$statedir/openssl"
+cadir="$destdir/$statedir/openssl"
 
 
 for i in "$@"; do

--- a/test_update_ca_certificates.py
+++ b/test_update_ca_certificates.py
@@ -51,9 +51,10 @@ def test_prints_help(container):
         container.run_expect([0], "/bin/update-ca-certificates --help").stdout
         == """USAGE: /bin/update-ca-certificates [OPTIONS]
 OPTIONS:
-  --verbose, -v     verbose output
-  --fresh, -f       start from scratch
-  --help, -h        this screen
+  --verbose, -v       verbose output
+  --root <Directory>  Root directory to use (default: /)
+  --fresh, -f         start from scratch
+  --help, -h          this screen
 """
     )
 

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -28,6 +28,7 @@ statedir='/var/lib/ca-certificates'
 hooksdir1='/etc/ca-certificates/update.d'
 hooksdir2='/usr/lib/ca-certificates/update.d'
 verbose=
+destdir=/
 fresh=
 
 export statedir
@@ -37,9 +38,10 @@ help_and_exit()
     cat <<-EOF
 	USAGE: $0 [OPTIONS]
 	OPTIONS:
-	  --verbose, -v     verbose output
-	  --fresh, -f       start from scratch
-	  --help, -h        this screen
+	  --verbose, -v       verbose output
+	  --root <Directory>  Root directory to use (default: $destdir)
+	  --fresh, -f         start from scratch
+	  --help, -h          this screen
 EOF
     exit 0
 }
@@ -48,6 +50,14 @@ for arg in "$@"; do
     case "$arg" in
         -v|--verbose) verbose='-v' ;;
         -f|--fresh) fresh='-f' ;;
+		-r|--root)
+			shift
+			destdir=$1
+			if [ -z $destdir ]; then
+				echo "-r option requires parameter <directory>"
+				exit 1
+			fi
+			;;
         -h|--help) help_and_exit ;;
         -*) echo "invalid option: $1" >&2; exit 1 ;;
     esac

--- a/update-ca-certificates.8
+++ b/update-ca-certificates.8
@@ -46,6 +46,9 @@ Show summary of options.
 .B \-v, \-\-verbose
 Be verbose. Output \fBc_rehash\fP.
 .TP
+.B \-r, \-\-root <Directory>
+Root Directory to use (defaults to / if not specified).
+.TP
 .B \-f, \-\-fresh
 Fresh updates. Don't update stores incrementally but create from scratch.
 .SH FILES


### PR DESCRIPTION
This can be used to generate a bundle in a base root directory other than /,
for example useful for building static certificate bundles.