### PR TITLE
update-ca-certificates failing often at deployment on SLE15

### DIFF
--- a/certbundle.run
+++ b/certbundle.run
@@ -19,7 +19,7 @@ if [ -z "$fresh" -a "$cafile" -nt "$cadir" ]; then
 	exit 0
 fi
 [ -z "$verbose" ] || echo "creating $cafile ..."
-trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors $cafile.tmp
+trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors --overwrite $cafile.tmp
 cat - $cafile.tmp > "$cafile.new" <<EOF
 #
 # automatically created by $0. Do not edit!

--- a/certbundle.run
+++ b/certbundle.run
@@ -19,7 +19,8 @@ if [ -z "$fresh" -a "$cafile" -nt "$cadir" ]; then
 	exit 0
 fi
 [ -z "$verbose" ] || echo "creating $cafile ..."
-cat > "$cafile.new" <<EOF
+trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors $cafile.tmp
+cat - $cafile.tmp > "$cafile.new" <<EOF
 #
 # automatically created by $0. Do not edit!
 #
@@ -32,7 +33,5 @@ cat > "$cafile.new" <<EOF
 # - gnutls: gnutls_certificate_set_x509_system_trust(cred)
 #
 EOF
-trust extract --format=pem-bundle --purpose=server-auth --filter=ca-anchors $cafile.tmp
-cat $cafile.tmp >> $cafile.new
 rm -f $cafile.tmp
-mv "$cafile.new" "$cafile"
+mv -f "$cafile.new" "$cafile"

--- a/certbundle.run
+++ b/certbundle.run
@@ -3,8 +3,9 @@
 
 set -e
 
-cafile="/var/lib/ca-certificates/ca-bundle.pem"
-cadir="/var/lib/ca-certificates/pem"
+[ -d "$statedir" ]
+cafile="$statedir/ca-bundle.pem"
+cadir="$statedir/pem"
 
 for i in "$@"; do
 	if [ "$i" = "-f" ]; then

--- a/etc_ssl.run
+++ b/etc_ssl.run
@@ -23,8 +23,9 @@
 # USA.
 #
 
+[ -d "$statedir" ]
 etccertsdir="/etc/ssl/certs"
-pemdir="/var/lib/ca-certificates/pem"
+pemdir="$statedir/pem"
 
 help_and_exit()
 {
@@ -45,6 +46,7 @@ case "$1" in
     -*) echo "invalid option: $1" >&2; exit 1 ;;
 esac
 
+mkdir -p "$pemdir"
 trust extract --purpose=server-auth --filter=ca-anchors --format=pem-directory-hash -f "$pemdir"
 
 # fix up /etc/ssl/certs if it's not a link pointing to /var/lib/ca-certificates/pem

--- a/java.run
+++ b/java.run
@@ -2,9 +2,9 @@
 
 set -e
 
-cafile="/var/lib/ca-certificates/java-cacerts"
-cafile_gcj="/var/lib/ca-certificates/gcj-cacerts"
-cadir="/var/lib/ca-certificates/pem"
+[ -d "$statedir" ]
+cafile="$statedir/java-cacerts"
+cafile_gcj="$statedir/gcj-cacerts"
 
 
 for i in "$@"; do

--- a/java.run
+++ b/java.run
@@ -16,6 +16,7 @@ for i in "$@"; do
 done
 
 [ -z "$verbose" ] || echo "creating $cafile ..."
-trust extract --format=java-cacerts --purpose=server-auth --filter=ca-anchors --overwrite $cafile
+trust extract --format=java-cacerts --purpose=server-auth --filter=ca-anchors --overwrite $cafile.new
+mv $cafile.new $cafile
 
 # vim: syntax=sh

--- a/openssl.run
+++ b/openssl.run
@@ -2,7 +2,8 @@
 
 set -e
 
-cadir="/var/lib/ca-certificates/openssl"
+[ -d "$statedir" ]
+cadir="$statedir/openssl"
 
 
 for i in "$@"; do
@@ -14,6 +15,7 @@ for i in "$@"; do
 done
 
 [ -z "$verbose" ] || echo "creating $cadir ..."
+mkdir -p "$cadir"
 trust extract --format=openssl-directory --filter=ca-anchors --overwrite $cadir
 
 # vim: syntax=sh

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -24,10 +24,13 @@
 # USA.
 #
 
+statedir='/var/lib/ca-certificates'
 hooksdir1='/etc/ca-certificates/update.d'
 hooksdir2='/usr/lib/ca-certificates/update.d'
 verbose=
 fresh=
+
+export statedir
 
 help_and_exit()
 {
@@ -59,6 +62,8 @@ case "${TRANSACTIONAL_UPDATE,,*}" in
 	;;
 esac
 rm -f /etc/pki/trust/.updated
+
+mkdir -p "$statedir"
 
 while read s f; do
     if [ -L "$f" -a "`readlink "$f"`" = "/dev/null" ]; then

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -3,7 +3,7 @@
 # update-ca-certificates
 #
 # Copyright (c) 2010,2013 SUSE Linux Products GmbH
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020,2021 SUSE LLC
 # Author: Ludwig Nussel
 #
 # Inspired by Debian's update-ca-certificates
@@ -64,6 +64,13 @@ esac
 rm -f /etc/pki/trust/.updated
 
 mkdir -p "$statedir"
+# serialize calls if we can
+if [ -z "$_CA_CERTIFICATES_LOCKED" -a -x /usr/bin/flock ]; then
+    export _CA_CERTIFICATES_LOCKED="1"
+    exec /usr/bin/flock "$statedir" "$0" "$@"
+    echo "failed to lock $statedir\n" >&2
+    exit 1
+fi
 
 while read s f; do
     if [ -L "$f" -a "`readlink "$f"`" = "/dev/null" ]; then


### PR DESCRIPTION
These patches are need to address an issue with serialization in
 update-ca-certificates which causes it to fail often at deployment