### PR TITLE
Sync directories with p11-kit [bsc#1251012]

### DIFF
--- a/README
+++ b/README
@@ -41,7 +41,7 @@ Differences to previous versions on openSUSE
   openssl's 'trusted' format.
 
 - /etc/ca-certificates.conf is no longer supported. Just symlink the
-  certificates you don't want to /etc/pki/trust/blacklist.
+  certificates you don't want to /etc/pki/trust/blocklist.
 
 Differences to Debian
 =====================

--- a/ca-certificates.path
+++ b/ca-certificates.path
@@ -7,7 +7,7 @@ Unit=ca-certificates.service
 PathExists=/etc/pki/trust/.updated
 PathChanged=/etc/pki/trust
 PathChanged=/etc/pki/trust/anchors
-PathChanged=/etc/pki/trust/blacklist
+PathChanged=/etc/pki/trust/blocklist
 
 [Install]
 WantedBy=default.target

--- a/ca-certificates.spec
+++ b/ca-certificates.spec
@@ -15,6 +15,10 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%define ssletcdir %{_sysconfdir}/ssl
+%define cabundle  %{_localstatedir}/lib/ca-certificates/ca-bundle.pem
+%define sslcerts  %{ssletcdir}/certs
+
 %if 0%{?_build_in_place}
 %define git_version %(git log '-n1' '--date=format:%Y%m%d' '--no-show-signature' "--pretty=format:+git%cd.%h")
 BuildRequires:  git-core
@@ -31,31 +35,27 @@ BuildRequires:  git-core
 # on top of gnutls that we have to live with the bundle for now
 %bcond_without cabundle
 
-BuildRequires:  p11-kit-devel
-
 Name:           ca-certificates
-%define ssletcdir %{_sysconfdir}/ssl
-%define cabundle  /var/lib/ca-certificates/ca-bundle.pem
-%define sslcerts  %{ssletcdir}/certs
 Version:        2%{git_version}
 Release:        0
 Summary:        Utilities for system wide CA certificate installation
 License:        GPL-2.0-or-later
 Group:          Productivity/Networking/Security
-Source0:        ca-certificates-%{version}.tar
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 URL:            https://github.com/openSUSE/ca-certificates
+Source0:        ca-certificates-%{version}.tar
+BuildRequires:  p11-kit-devel
 #
-Requires:       /usr/bin/readlink
+Requires:       %{_bindir}/readlink
 Requires:       p11-kit
 Requires:       p11-kit-tools >= 0.23.1
 # needed for post
-Requires(post): p11-kit-tools /usr/bin/readlink
+Requires(post): %{_bindir}/readlink
+Requires(post): p11-kit-tools
 Recommends:     ca-certificates-mozilla
 # no need for a separate Java package anymore. The bundle is
 # created by C code.
 Obsoletes:      java-ca-certificates = 1
-Provides:       java-ca-certificates = %version-%release
+Provides:       java-ca-certificates = %{version}-%{release}
 BuildArch:      noarch
 
 %description
@@ -73,20 +73,18 @@ certificate store that is managed by p11-kit.
 rm -f certbundle.run
 %endif
 %make_install
-install -d -m 755 %{buildroot}%{trustdir_cfg}/{anchors,blacklist}
-install -d -m 755 %{buildroot}%{trustdir_static}/{anchors,blacklist}
 install -d -m 755 %{buildroot}%{ssletcdir}
-install -d -m 755 %{buildroot}/etc/ca-certificates/update.d
+install -d -m 755 %{buildroot}%{_sysconfdir}/ca-certificates/update.d
 install -d -m 755 %{buildroot}%{_prefix}/lib/ca-certificates/update.d
-install -d -m 555 %{buildroot}/var/lib/ca-certificates/pem
-install -d -m 555 %{buildroot}/var/lib/ca-certificates/openssl
+install -d -m 555 %{buildroot}%{_localstatedir}/lib/ca-certificates/pem
+install -d -m 555 %{buildroot}%{_localstatedir}/lib/ca-certificates/openssl
 install -d -m 755 %{buildroot}/%{_prefix}/lib/systemd/system
-ln -s ../../var/lib/ca-certificates/pem %{buildroot}%{sslcerts}
+ln -s ../..%{_localstatedir}/lib/ca-certificates/pem %{buildroot}%{sslcerts}
 %if %{with cabundle}
 install -D -m 444 /dev/null %{buildroot}/%{cabundle}
 ln -s %{cabundle} %{buildroot}%{ssletcdir}/ca-bundle.pem
 %endif
-install -D -m 444 /dev/null %{buildroot}/var/lib/ca-certificates/java-cacerts
+install -D -m 444 /dev/null %{buildroot}%{_localstatedir}/lib/ca-certificates/java-cacerts
 
 %pre
 %service_add_pre ca-certificates.path ca-certificates.service ca-certificates-setup.service
@@ -101,38 +99,26 @@ update-ca-certificates -f || true
 
 %postun
 if [ "$1" -eq 0 ]; then
-	rm -rf /var/lib/ca-certificates/pem /var/lib/ca-certificates/openssl
+	rm -rf %{_localstatedir}/lib/ca-certificates/pem %{_localstatedir}/lib/ca-certificates/openssl
 fi
 %service_del_postun ca-certificates.path ca-certificates.service ca-certificates-setup.service
 
-%clean
-rm -rf %{buildroot}
-
 %files
-%defattr(-, root, root)
 %license COPYING
 %doc README
-%dir %{pkidir_cfg}
-%dir %{trustdir_cfg}
-%dir %{trustdir_cfg}/anchors
-%dir %{trustdir_cfg}/blacklist
-%dir %{pkidir_static}
-%dir %{trustdir_static}
-%dir %{trustdir_static}/anchors
-%dir %{trustdir_static}/blacklist
-%dir %ssletcdir
-%sslcerts
-%ghost /var/lib/ca-certificates/java-cacerts
-%dir /etc/ca-certificates
-%dir /etc/ca-certificates/update.d
+%dir %{ssletcdir}
+%{sslcerts}
+%ghost %{_localstatedir}/lib/ca-certificates/java-cacerts
+%dir %{_sysconfdir}/ca-certificates
+%dir %{_sysconfdir}/ca-certificates/update.d
 %dir %{_prefix}/lib/ca-certificates
 %dir %{_prefix}/lib/ca-certificates/update.d
 %{_prefix}/lib/systemd/system/*
-%dir /var/lib/ca-certificates
-%dir /var/lib/ca-certificates/pem
-%dir /var/lib/ca-certificates/openssl
+%dir %{_localstatedir}/lib/ca-certificates
+%dir %{_localstatedir}/lib/ca-certificates/pem
+%dir %{_localstatedir}/lib/ca-certificates/openssl
 %{_sbindir}/update-ca-certificates
-%{_mandir}/man8/update-ca-certificates.8*
+%{_mandir}/man8/update-ca-certificates.8%{?ext_man}
 %{_prefix}/lib/ca-certificates/update.d/*java.run
 %{_prefix}/lib/ca-certificates/update.d/*etc_ssl.run
 %{_prefix}/lib/ca-certificates/update.d/*openssl.run

--- a/update-ca-certificates.8
+++ b/update-ca-certificates.8
@@ -30,7 +30,7 @@ resp /etc/pki/trust/anchors but there could be other plugins that
 serve as source for certificates as well.
 .PP
 To blacklist certificates symlinks to the respective certificates
-can be placed in /etc/pki/trust/blacklist
+can be placed in /etc/pki/trust/blocklist
 .PP
 \fBupdate-ca-certificates\fP invokes
 custom hooks in /usr/lib/ca-certificates/update.d/*.run and
@@ -56,13 +56,13 @@ Fresh updates. Don't update stores incrementally but create from scratch.
 .I /usr/share/pki/trust/anchors
 Directory of CA certificate trust anchors.
 .TP
-.I /usr/share/pki/trust/blacklist
+.I /usr/share/pki/trust/blocklist
 Directory of blacklisted CA certificates
 .TP
 .I /etc/pki/trust/anchors
 Directory of CA certificate trust anchors for use by the admin
 .TP
-.I /etc/pki/trust/blacklist
+.I /etc/pki/trust/blocklist
 Directory of blacklisted CA certificates for use by the admin
 .SH SEE ALSO
 .BR c_rehash (1),


### PR DESCRIPTION
Don't package p11-kit directories, so that we find changes earlier and don't run into conflicting permissions by accident.