### PR TITLE
Avoid process substitution in the update-certificates script

### DIFF
--- a/test_update_ca_certificates.py
+++ b/test_update_ca_certificates.py
@@ -6,11 +6,8 @@ HOOKSDIR2 = "/usr/lib/ca-certificates/update.d"
 HOOK_ARGS_PATH = "/hook_args"
 LISTENER_SCRIPT_DEST = HOOKSDIR2 + "/foo.run"
 
-LISTENER_SCRIPT = (
-    r"""#!/bin/bash
-echo "\$@" > """
-    + HOOK_ARGS_PATH
-)
+LISTENER_SCRIPT = r"""#!/bin/bash
+echo "\$@" > """ + HOOK_ARGS_PATH
 
 BAR_HOOK = "bar.run"
 

--- a/update-ca-certificates
+++ b/update-ca-certificates
@@ -101,7 +101,7 @@ function find_hooks {
     done
 }
 
-while read s f; do
+find_hooks | sort -k 1,1 -u | while read s f; do
     if [ -L "$f" -a "`readlink "$f"`" = "/dev/null" ]; then
 	[ -z "$verbose" ] || echo "skipping $f"
 	continue
@@ -109,5 +109,5 @@ while read s f; do
 	[ -z "$verbose" ] || echo "running $f .."
     fi
     "$f" $fresh $verbose
-done < <(find_hooks|sort -k 1,1 -u)
+done
 chmod 0555 "$destdir/$statedir"


### PR DESCRIPTION
Bash process substitution requires a working `/dev/fd`, which may be missing in nested `chroot/container` builds. Use regular pipeline/temporary file input instead in restricted build roots.

References: https://github.com/openSUSE/brp-check-suse/issues/54